### PR TITLE
Refactor the temperature controller lookup not to use a map

### DIFF
--- a/devices/temperature_controller_test.go
+++ b/devices/temperature_controller_test.go
@@ -17,6 +17,7 @@ func TestCreateTemperatureController(t *testing.T) {
 	}
 
 	t.Run("A new Temperature controller is created if no existing device with the same name exists", func(t *testing.T) {
+		devices.ClearControllers()
 		temperatureController, err := devices.CreateTemperatureController("sample", &probe)
 		if err != nil {
 			t.Fatalf("Failed to create the Temperature Controller: %v", err)
@@ -51,6 +52,29 @@ func TestCreateTemperatureController(t *testing.T) {
 			t.Fatalf("Expected %v, but got %v", existingController, temperatureController)
 		}
 	})
+
+	t.Run("A Temperature controller is returned by reference", func(t *testing.T) {
+		temperatureController, err := devices.CreateTemperatureController("sample_2", &probe)
+
+		if err == nil {
+			t.Fatalf("Created a duplicate Temperature controller: %v", temperatureController)
+		}
+	})
+
+	t.Run("Updating a temperature controller name makes it findable by default", func(t *testing.T) {
+		devices.ClearControllers()
+		temperatureController, err := devices.CreateTemperatureController("sample", &probe)
+		if err != nil {
+			t.Fatalf("Failed to create the Temperature Controller: %v", err)
+		}
+
+		temperatureController.Name = "Some new name"
+
+		existingController := devices.FindTemperatureControllerByName("Some new name")
+		if temperatureController != existingController {
+			t.Fatalf("Expected %v, but got %v", existingController, temperatureController)
+		}
+	})
 }
 
 func TestTemperatureControllerAverageTemperature(t *testing.T) {
@@ -67,7 +91,8 @@ func TestTemperatureControllerAverageTemperature(t *testing.T) {
 	}
 
 	t.Run("With a single probe, you get the current value", func(t *testing.T) {
-		err = probe.UpdateTemperature("35C"); if err != nil {
+		err = probe.UpdateTemperature("35C")
+		if err != nil {
 			log.Fatalf("Failed to update %v", err)
 		}
 		avgTemperature := temperatureController.AverageTemperature()
@@ -82,19 +107,66 @@ func TestTemperatureControllerAverageTemperature(t *testing.T) {
 			Address:  onewire.Address(123456),
 			Reading:  physic.Temperature(0),
 		}
-		_, err = devices.CreateTemperatureController("sample", &probe_two); if err != nil {
+		_, err = devices.CreateTemperatureController("sample", &probe_two)
+		if err != nil {
 			log.Fatalf("Failed to create %v", err)
 		}
 
 		// probe.Reading = new(physic.Temperature)
 		// probe.Reading.Set("35C")
-		err = probe_two.UpdateTemperature("37C"); if err != nil {
+		err = probe_two.UpdateTemperature("37C")
+		if err != nil {
 			log.Fatalf("Failed to update %v", err)
 		}
 
 		avgTemperature := temperatureController.AverageTemperature()
 		if float64(36.0) != avgTemperature.Celsius() {
 			t.Fatalf("Expected 36C, but got %v", avgTemperature)
+		}
+	})
+}
+
+func TestTemperatureControllerUpdateOutput(t *testing.T) {
+	devices.ClearControllers()
+
+	probe := devices.TemperatureProbe{
+		PhysAddr: "ARealAddress",
+		Address:  onewire.Address(12345),
+		Reading:  physic.Temperature(0),
+	}
+	err := probe.UpdateTemperature("35C")
+	if err != nil {
+		log.Fatalf("Failed to update %v", err)
+	}
+	temperatureController, err := devices.CreateTemperatureController("sample", &probe)
+
+	if err != nil {
+		t.Fatalf("Failed to create the controller: %v", err)
+	}
+
+	t.Run("Adds to the last readings up to 5 times", func(t *testing.T) {
+		for i := 1; i <= 5; i++ {
+			temperatureController.UpdateOutput()
+			if i != len(temperatureController.LastReadings) {
+				t.Fatalf("Expected %v temperature reading but got %v", i, len(temperatureController.LastReadings))
+			}
+		}
+	})
+
+	t.Run("The 6th temperature removes the oldest temperature", func(t *testing.T) {
+		toDelete := temperatureController.LastReadings[0]
+
+		if 5 != len(temperatureController.LastReadings) {
+			t.Fatalf("Expected %v temperature reading but got %v", 5, len(temperatureController.LastReadings))
+		}
+
+		temperatureController.UpdateOutput()
+		if 5 != len(temperatureController.LastReadings) {
+			t.Fatalf("Expected %v temperature reading but got %v", 5, len(temperatureController.LastReadings))
+		}
+
+		if &temperatureController.LastReadings[0] == &toDelete {
+			t.Fatalf("Expected %v to not be the same as the deleted value!", temperatureController.LastReadings[0])
 		}
 	})
 }


### PR DESCRIPTION
Trying to get to grips with References again is a pain, so I'm simplifying things a bit by switching to an array instead of a map, that way updating the name of a temperature controller doesn't require an additional change to the key of a map.

And test more stuff