### PR TITLE
Add GORM as an ORM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ elsinore
 
 # IDE Stuff
 .vscode
+
+# Local files
+**/*.db

--- a/devices/temperature_probe.go
+++ b/devices/temperature_probe.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"time"
 
+	"gorm.io/gorm"
 	"periph.io/x/periph/conn/onewire"
 	"periph.io/x/periph/conn/physic"
 	"periph.io/x/periph/devices/ds18b20"
@@ -22,10 +23,12 @@ var probes = make(map[string]*TemperatureProbe)
 // Address -> The unsigned int value for the readings
 // Reading -> The actual reading as a Physic.Temperature
 type TemperatureProbe struct {
-	PhysAddr   string          `json:"physAddr"`
-	Address    onewire.Address `json:"address"`
-	ReadingRaw physic.Temperature
-	Updated    time.Time `json:"updatedAt"`
+	gorm.Model
+	PhysAddr                string
+	Address                 onewire.Address
+	ReadingRaw              physic.Temperature `gorm:"-"`
+	Updated                 time.Time          `gorm:"-"`
+	TemperatureControllerID uint
 }
 
 // UpdateTemperature Set the temperature on the Temperature Probe from a string
@@ -33,6 +36,7 @@ func (t *TemperatureProbe) UpdateTemperature(newTemp string) error {
 	return t.ReadingRaw.Set(newTemp)
 }
 
+// Reading The current temperature reading for the probe
 func (t *TemperatureProbe) Reading() string {
 	return t.ReadingRaw.String()
 }

--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,11 @@ require (
 	github.com/99designs/gqlgen v0.13.0
 	github.com/google/go-cmp v0.5.4
 	github.com/kr/pretty v0.2.1 // indirect
+	github.com/mattn/go-sqlite3 v1.14.6 // indirect
 	github.com/stretchr/testify v1.4.0
 	github.com/vektah/gqlparser/v2 v2.1.0
 	golang.org/x/net v0.0.0-20210119194325-5f4716e94777 // indirect
+	gorm.io/driver/sqlite v1.1.4
+	gorm.io/gorm v1.21.7
 	periph.io/x/periph v3.6.7+incompatible
 )

--- a/go.sum
+++ b/go.sum
@@ -31,6 +31,11 @@ github.com/graphql-go/relay v0.0.0-20171208134043-54350098cfe5 h1:7fNeIw+3vvQjnJ
 github.com/graphql-go/relay v0.0.0-20171208134043-54350098cfe5/go.mod h1:JaXUeU9JGLA7FGTZJ254WFzDz8NMfE9Pym6ipTmFnP4=
 github.com/hashicorp/golang-lru v0.5.0 h1:CL2msUPvZTLb5O648aiLNJw3hnBxN2+1Jq8rCOH9wdo=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD/E=
+github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
+github.com/jinzhu/now v1.1.1/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
+github.com/jinzhu/now v1.1.2 h1:eVKgfIdy9b6zbWBMgFpfDPoAMifwSZagU9HmEU6zgiI=
+github.com/jinzhu/now v1.1.2/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
@@ -43,6 +48,10 @@ github.com/matryer/moq v0.0.0-20200106131100-75d0ddfc0007/go.mod h1:9ELz6aaclSIG
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
+github.com/mattn/go-sqlite3 v1.14.5 h1:1IdxlwTNazvbKJQSxoJ5/9ECbEeaTTyeU7sEAZ5KKTQ=
+github.com/mattn/go-sqlite3 v1.14.5/go.mod h1:WVKg1VTActs4Qso6iwGbiFih2UIHo0ENGwNd0Lj+XmI=
+github.com/mattn/go-sqlite3 v1.14.6 h1:dNPt6NO46WmLVt2DLNpwczCmdV5boIZ6g/tlDrlRUbg=
+github.com/mattn/go-sqlite3 v1.14.6/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
 github.com/mitchellh/mapstructure v0.0.0-20180203102830-a4e142e9c047 h1:zCoDWFD5nrJJVjbXiDZcVhOBSzKn3o9LgRLLMRNuru8=
 github.com/mitchellh/mapstructure v0.0.0-20180203102830-a4e142e9c047/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/opentracing/basictracer-go v1.0.0/go.mod h1:QfBfYuafItcjQuMwinw9GhYKwFXS9KnPs5lxoYwgW74=
@@ -100,6 +109,11 @@ gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4 h1:/eiJrUcujPVeJ3xlSWaiNi3uSVmDGBK1pDHUHAnao1I=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gorm.io/driver/sqlite v1.1.4 h1:PDzwYE+sI6De2+mxAneV9Xs11+ZyKV6oxD3wDGkaNvM=
+gorm.io/driver/sqlite v1.1.4/go.mod h1:mJCeTFr7+crvS+TRnWc5Z3UvwxUN1BGBLMrf5LA9DYw=
+gorm.io/gorm v1.20.7/go.mod h1:0HFTzE/SqkGTzK6TlDPPQbAYCluiVvhzoA1+aVyzenw=
+gorm.io/gorm v1.21.7 h1:MuY8oejVL5l3iT7PfE3z5I4J+KW/Nu2w/uTpLe3vV1Q=
+gorm.io/gorm v1.21.7/go.mod h1:F+OptMscr0P2F2qU97WT1WimdH9GaQPoDW7AYd5i2Y0=
 periph.io/x/conn v0.0.0-20201229155756-6ef5117d7267 h1:hE3SnWytl/gaEF70qlWN5YREopMsvsJB4vLkWXZKZQg=
 periph.io/x/conn v0.0.2 h1:Skl3egL0ON+ihyPojXbX3HIpwESBvt2QsOtZo5fGLVQ=
 periph.io/x/conn/v3 v3.6.7 h1:hem/gzoUI0tnvdJOJAk+XLBhqBGX9sHkwShBXRGGy0k=

--- a/graph/resolver.go
+++ b/graph/resolver.go
@@ -5,4 +5,5 @@ package graph
 // It serves as dependency injection for your app, add any dependencies you require here.
 //go:generate go run github.com/99designs/gqlgen
 
+// Resolver Resolver
 type Resolver struct{}


### PR DESCRIPTION
Basic first implementation, no actual CRUD is implemented yet.

I chose [GORM](https://gorm.io/) because it showed up on my first Google for Go ORM, and it's really well [documented](https://gorm.io/docs/) to make it understandable.

Since I'm using SQLite, I had to disable [Foreign Key Constraints](https://gorm.io/docs/gorm_config.html#DisableForeignKeyConstraintWhenMigrating) because it does not support foreign keys.