### PR TITLE
Add a mutation to remove a probe from  a controller

### DIFF
--- a/devices/temperature_controller.go
+++ b/devices/temperature_controller.go
@@ -122,6 +122,17 @@ func CreateTemperatureController(name string, probe *TemperatureProbe) (*Tempera
 	return controller, nil
 }
 
+func (c *TemperatureController) RemoveProbe(physAddr string) error {
+	for i, probe := range c.TemperatureProbes {
+		if probe.PhysAddr == physAddr {
+			c.TemperatureProbes[i] = c.TemperatureProbes[len(c.TemperatureProbes)-1]
+			c.TemperatureProbes = c.TemperatureProbes[:len(c.TemperatureProbes)-1]
+			return nil
+		}
+	}
+	return fmt.Errorf("Could not find a probe with address %v", physAddr)
+}
+
 // UpdateOutput updates the temperatures and decides how to control the outputs
 func (c *TemperatureController) UpdateOutput() {
 	if len(c.LastReadings) >= 5 {

--- a/graph/resolver_test.go
+++ b/graph/resolver_test.go
@@ -166,7 +166,7 @@ func TestMutations(t *testing.T) {
 		}
 	}
 
-	t.Run("CreateTemperatureController saves to the DB", func(t *testing.T) {
+	t.Run("assignProbe saves to the DB", func(t *testing.T) {
 		c.MustPost(`
 		mutation {
 			assignProbe(settings: { address: "ARealAddress", name: "TEST PROBE"}) {
@@ -187,6 +187,33 @@ func TestMutations(t *testing.T) {
 		`, &assignRespTwo)
 
 		require.Equal(t, "2", assignRespTwo.AssignProbe.ID)
+	})
+
+	var removeResp struct {
+		RemoveProbeFromController struct {
+			ID   string
+			Name string
+		}
+		Errors []struct {
+			Message   string
+			Locations []struct {
+				Line   int
+				Column int
+			}
+		}
+	}
+
+	t.Run("removeProbeFromController removes a probe from the controller", func(t *testing.T) {
+		c.MustPost(`
+		mutation {
+			removeProbeFromController(address: "ARealAddress") {
+				id
+				name
+			}
+		}
+		`, &removeResp)
+
+		require.Equal(t, "1", removeResp.RemoveProbeFromController.ID)
 	})
 
 	database.Close()

--- a/graph/schema.graphqls
+++ b/graph/schema.graphqls
@@ -50,6 +50,7 @@ type ManualSettings {
 
 type Mutation {
   assignProbe(settings: probeSettings): TemperatureController
+  removeProbeFromController(address: String): TemperatureController
 }
 
 """The settings for heating or cooling on a temperature controller"""

--- a/graph/schema.resolvers.go
+++ b/graph/schema.resolvers.go
@@ -29,6 +29,15 @@ func (r *mutationResolver) AssignProbe(ctx context.Context, settings *model.Prob
 	return nil, fmt.Errorf("Coud not find a probe for %v", *settings.Address)
 }
 
+func (r *mutationResolver) RemoveProbeFromController(ctx context.Context, address *string) (*devices.TemperatureController, error) {
+	controller := devices.FindTemperatureControllerForProbe(*address)
+	if controller == nil {
+		return nil, fmt.Errorf("No controller could be found for %v", address)
+	}
+	error := controller.RemoveProbe(*address)
+	return controller, error
+}
+
 func (r *pidSettingsResolver) ID(ctx context.Context, obj *devices.PidSettings) (string, error) {
 	return fmt.Sprint(obj.ID), nil
 }


### PR DESCRIPTION
This adds the ability to remove a probe from a controller, I'm going to switch test suite after this since it's a pain when a test fails and the DB doesn't get cleaned up