### PR TITLE
Switch to using a test helper with a cleanup method for the DB

### DIFF
--- a/devices/temperature_controller_test.go
+++ b/devices/temperature_controller_test.go
@@ -13,6 +13,22 @@ import (
 	"periph.io/x/periph/conn/physic"
 )
 
+func setupTestDb(t *testing.T) {
+	dbName := "test"
+	database.InitDatabase(&dbName,
+		&devices.TemperatureProbe{}, &devices.PidSettings{}, &devices.HysteriaSettings{},
+		&devices.ManualSettings{}, &devices.TemperatureController{},
+	)
+
+	t.Cleanup(func() {
+		database.Close()
+		e := os.Remove("test.db")
+		if e != nil {
+			t.Fatal(e)
+		}
+	})
+}
+
 func TestCreateTemperatureController(t *testing.T) {
 	devices.ClearControllers()
 	probe := devices.TemperatureProbe{
@@ -82,14 +98,7 @@ func TestCreateTemperatureController(t *testing.T) {
 }
 
 func TestPersistenceTemperatureController(t *testing.T) {
-	dbName := "test"
-	database.InitDatabase(&dbName,
-		&devices.TemperatureProbe{}, &devices.PidSettings{}, &devices.HysteriaSettings{},
-		&devices.ManualSettings{}, &devices.TemperatureController{},
-	)
-	if database.FetchDatabase() == nil {
-		t.Fatal("No Database configured")
-	}
+	setupTestDb(t)
 	devices.ClearControllers()
 	probe := devices.TemperatureProbe{
 		PhysAddr: "ARealAddress",
@@ -113,12 +122,6 @@ func TestPersistenceTemperatureController(t *testing.T) {
 			t.Fatalf("Expected the temperature controller to be called sample, but got %v", temperatureController.Name)
 		}
 	})
-
-	database.Close()
-	e := os.Remove("test.db")
-	if e != nil {
-		t.Fatal(e)
-	}
 }
 
 func TestTemperatureControllerAverageTemperature(t *testing.T) {


### PR DESCRIPTION
Just a basic bit of code tidying up, switch to use a helper method (not a real helper method since it's not shared across packages and I'm unsure how to do it.

But it does use `Testing.Cleanup` which is significantly better than the old way