### PR TITLE
Add outputcontrol

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       matrix:
         go-version: [1.14.x, 1.15.x, 1.16.x]
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install Go

--- a/README.md
+++ b/README.md
@@ -34,7 +34,11 @@ This can be built for any platform you want, CI runs against Windows, Mac, and L
 
 Currently, the scripts in this repo target Linux as the build host, since that's what I use as my primary development platform (I don't have a Windows machine, I'm open to pull requests)
 
-`bin/build_all` -> This will build Elsinores backend/server side for Linux and RaspberryPi targets, placing the binaries in the `builds/<platform>` directories as appropriate.
+This application is designed to use [xgo2](https://github.com/youchainhq/xgo2) (for local builds) but you can use [xgo]((https://github.com/karalabe/xgo/)) with this application if you don't want to download.
+
+The reason for this is that libsqlite does not like using cross compiled go `CGO_ENABLED=1` on target systems.
+
+`bin/build_all` -> This will build Elsinores backend/server side for Linux and RaspberryPi targets, placing the binaries in the `builds/` directory as appropriate.
 
 ## Running
 

--- a/bin/build_all
+++ b/bin/build_all
@@ -1,2 +1,1 @@
-env GOOS=linux GOARCH=arm GOARM=5 go build -o builds/raspberrypi/elsinore
-go build -o builds/linux/elsinore
+xgo2 --targets=linux/arm-6 -out builds/elsinore ./

--- a/devices/output_control.go
+++ b/devices/output_control.go
@@ -1,0 +1,124 @@
+package devices
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"gorm.io/gorm"
+	"periph.io/x/periph/conn/gpio"
+	"periph.io/x/periph/conn/gpio/gpioreg"
+)
+
+// OutputControl is a basic struct to handle heating outputs with a duty cyclke
+type OutputControl struct {
+	gorm.Model
+	HeatOutput *OutPin
+	DutyCycle  int64 `gorm:"-"`
+	CycleTime  int64 `gorm:"-"`
+}
+
+// OutPin represents a stored output pin with a friendly name
+type OutPin struct {
+	gorm.Model
+
+	Identifier   string
+	FriendlyName string
+	PinIO        gpio.PinIO `gorm:"-"`
+	onTime       *time.Time
+	offTime      *time.Time
+}
+
+func (op *OutPin) off() {
+	if op.offTime != nil {
+		return
+	}
+	if op.PinIO == nil {
+		op.PinIO = gpioreg.ByName(op.Identifier)
+	}
+
+	if err := op.PinIO.Out(gpio.Low); err != nil {
+		log.Fatal(err)
+	}
+
+	curTime := time.Now()
+	op.offTime = &curTime
+	op.onTime = nil
+}
+
+func (op *OutPin) on() {
+	if op.onTime != nil {
+		return
+	}
+	if op.PinIO == nil {
+		op.PinIO = gpioreg.ByName(op.Identifier)
+	}
+
+	if err := op.PinIO.Out(gpio.High); err != nil {
+		log.Fatal(err)
+	}
+
+	curTime := time.Now()
+	op.offTime = nil
+	op.onTime = &curTime
+}
+
+// CalculateOutput - Turn on and off the output pin for this output control depending on the duty cycle
+func (o *OutputControl) CalculateOutput() {
+	if o.HeatOutput.offTime == nil && o.HeatOutput.onTime == nil {
+		o.HeatOutput.off()
+	}
+	if o.DutyCycle == 0 {
+		o.HeatOutput.off()
+	} else if o.DutyCycle > 0 {
+		cycleSeconds := (o.CycleTime * o.DutyCycle) / 100
+		fmt.Printf("off: %v, on: %v", o.HeatOutput.offTime, o.HeatOutput.onTime)
+		if o.HeatOutput.onTime != nil {
+			// it's on, do we need to turn it off?
+			changeAt := time.Since(*o.HeatOutput.onTime)
+			if changeAt.Seconds() >= float64(cycleSeconds) {
+				fmt.Printf("Heat output turning off after %v seconds", changeAt.Seconds())
+				o.HeatOutput.off()
+			} else {
+				remaining := changeAt.Seconds() - float64(cycleSeconds)
+				fmt.Printf("Heat output to turn off in %v seconds", remaining)
+			}
+		} else if o.HeatOutput.offTime != nil {
+			// it's off, do we need to turn it on?
+			changeAt := time.Since(*o.HeatOutput.offTime)
+			offSeconds := o.CycleTime - cycleSeconds
+			if changeAt.Seconds() >= float64(offSeconds) {
+				fmt.Printf("Heat output turning on after %v seconds", changeAt.Seconds())
+				o.HeatOutput.on()
+			} else {
+				remaining := changeAt.Seconds() - float64(offSeconds)
+				fmt.Printf("Heat output to turn on in %v seconds", remaining)
+			}
+		}
+	} else if o.DutyCycle < 0 {
+		// No support for cooler outputs yet
+		o.HeatOutput.off()
+	}
+}
+
+// RunControl -> Run the output controller for a heating output
+func (o *OutputControl) RunControl() {
+	fmt.Println("Starting output control")
+	duration, err := time.ParseDuration("500ms")
+	if err != nil {
+		log.Fatal(err)
+	}
+	ticker := time.NewTicker(duration)
+	quit := make(chan struct{})
+
+	for {
+		select {
+		case <-ticker.C:
+			o.CalculateOutput()
+		case <-quit:
+			ticker.Stop()
+			fmt.Println("Stop")
+			return
+		}
+	}
+}

--- a/devices/output_control_test.go
+++ b/devices/output_control_test.go
@@ -1,0 +1,65 @@
+package devices_test
+
+import (
+	"log"
+	"testing"
+	"time"
+
+	"bou.ke/monkey"
+	"github.com/dougedey/elsinore/devices"
+	"periph.io/x/periph/conn/gpio"
+	"periph.io/x/periph/conn/gpio/gpiotest"
+)
+
+func TestOutputControl(t *testing.T) {
+	jumpDuration, err := time.ParseDuration("2s")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	testPin := gpiotest.Pin{N: "GPIO1", Num: 10, Fn: "I2C1_SDA"}
+	out21 := devices.OutPin{Identifier: "GPIO21", FriendlyName: "GPIO21", PinIO: &testPin}
+	outputControl := devices.OutputControl{HeatOutput: &out21, DutyCycle: 50, CycleTime: 4}
+
+	t.Run("OutputControl turns off imediately when there's no prior state", func(t *testing.T) {
+		if l := testPin.Read(); l != gpio.Low {
+			t.Fatal("expected off")
+		}
+
+		outputControl.CalculateOutput()
+
+		if l := testPin.Read(); l != gpio.Low {
+			t.Fatal("expected off")
+		}
+	})
+
+	t.Run("OutputControl waits for the off cycle time before turning on for 2s with a 50% duty cycle on a time of 4s", func(t *testing.T) {
+		if l := testPin.Read(); l != gpio.Low {
+			t.Fatal("expected off")
+		}
+
+		patch := monkey.Patch(time.Since, func(time.Time) time.Duration { return jumpDuration })
+		defer patch.Unpatch()
+
+		outputControl.CalculateOutput()
+
+		if l := testPin.Read(); l != gpio.High {
+			t.Fatal("expected on")
+		}
+	})
+
+	t.Run("OutputControl waits for the on cycle time before turning off for 2s with a 50% duty cycle on a time of 4s", func(t *testing.T) {
+		if l := testPin.Read(); l != gpio.High {
+			t.Fatal("expected on")
+		}
+
+		patch := monkey.Patch(time.Since, func(time.Time) time.Duration { return jumpDuration })
+		defer patch.Unpatch()
+
+		outputControl.CalculateOutput()
+
+		if l := testPin.Read(); l != gpio.Low {
+			t.Fatal("expected off")
+		}
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,13 @@ module github.com/dougedey/elsinore
 go 1.14
 
 require (
+	bou.ke/monkey v1.0.2
 	github.com/99designs/gqlgen v0.13.0
 	github.com/kr/pretty v0.2.1 // indirect
-	github.com/mattn/go-sqlite3 v1.14.6 // indirect
+	github.com/mxk/go-sqlite v0.0.0-20140611214908-167da9432e1f // indirect
 	github.com/stretchr/testify v1.4.0
 	github.com/vektah/gqlparser/v2 v2.1.0
+	github.com/youchainhq/xgo2 v0.0.0-20200618040405-6eb1e55cdbcb // indirect
 	gorm.io/driver/sqlite v1.1.4
 	gorm.io/gorm v1.21.7
 	periph.io/x/periph v3.6.7+incompatible

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+bou.ke/monkey v1.0.2 h1:kWcnsrCNUatbxncxR/ThdYqbytgOIArtYWqcQLQzKLI=
+bou.ke/monkey v1.0.2/go.mod h1:OqickVX3tNx6t33n1xvtTtu85YN5s6cKwVug+oHMaIA=
 github.com/99designs/gqlgen v0.13.0 h1:haLTcUp3Vwp80xMVEg5KRNwzfUrgFdRmtBY8fuB8scA=
 github.com/99designs/gqlgen v0.13.0/go.mod h1:NV130r6f4tpRWuAI+zsrSdooO/eWUv+Gyyoi3rEfXIk=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
@@ -28,6 +30,8 @@ github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkr
 github.com/jinzhu/now v1.1.1/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
 github.com/jinzhu/now v1.1.2 h1:eVKgfIdy9b6zbWBMgFpfDPoAMifwSZagU9HmEU6zgiI=
 github.com/jinzhu/now v1.1.2/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
+github.com/karalabe/xgo v0.0.0-20191115072854-c5ccff8648a7 h1:AYzjK/SHz6m6mg5iuFwkrAhCc14jvCpW9d6frC9iDPE=
+github.com/karalabe/xgo v0.0.0-20191115072854-c5ccff8648a7/go.mod h1:iYGcTYIPUvEWhFo6aKUuLchs+AV4ssYdyuBbQJZGcBk=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
@@ -46,6 +50,8 @@ github.com/mattn/go-sqlite3 v1.14.6 h1:dNPt6NO46WmLVt2DLNpwczCmdV5boIZ6g/tlDrlRU
 github.com/mattn/go-sqlite3 v1.14.6/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
 github.com/mitchellh/mapstructure v0.0.0-20180203102830-a4e142e9c047 h1:zCoDWFD5nrJJVjbXiDZcVhOBSzKn3o9LgRLLMRNuru8=
 github.com/mitchellh/mapstructure v0.0.0-20180203102830-a4e142e9c047/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
+github.com/mxk/go-sqlite v0.0.0-20140611214908-167da9432e1f h1:QlH4jpcTbMzpK5ymxjC6k/m22jkcS7uSUeiB9tF8qKs=
+github.com/mxk/go-sqlite v0.0.0-20140611214908-167da9432e1f/go.mod h1:pkc41e3zYdLbnNZr/Zr5u/Ozr7D0p8EorhQiE+DmM4Y=
 github.com/opentracing/basictracer-go v1.0.0/go.mod h1:QfBfYuafItcjQuMwinw9GhYKwFXS9KnPs5lxoYwgW74=
 github.com/opentracing/opentracing-go v1.0.2/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
@@ -71,6 +77,8 @@ github.com/vektah/dataloaden v0.2.1-0.20190515034641-a19b9a6e7c9e h1:+w0Zm/9gaWp
 github.com/vektah/dataloaden v0.2.1-0.20190515034641-a19b9a6e7c9e/go.mod h1:/HUdMve7rvxZma+2ZELQeNh88+003LL7Pf/CZ089j8U=
 github.com/vektah/gqlparser/v2 v2.1.0 h1:uiKJ+T5HMGGQM2kRKQ8Pxw8+Zq9qhhZhz/lieYvCMns=
 github.com/vektah/gqlparser/v2 v2.1.0/go.mod h1:SyUiHgLATUR8BiYURfTirrTcGpcE+4XkV2se04Px1Ms=
+github.com/youchainhq/xgo2 v0.0.0-20200618040405-6eb1e55cdbcb h1:hD8hn6p2rjBGhlSwdutzW63DoFpV70muzrLVQIDKDik=
+github.com/youchainhq/xgo2 v0.0.0-20200618040405-6eb1e55cdbcb/go.mod h1:sLKRscBHxXotxxtBGnhy8khBIwrB7qmC8rHCvFUUZ8E=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=

--- a/main.go
+++ b/main.go
@@ -43,6 +43,11 @@ func main() {
 	go hardware.ReadTemperatures(messages)
 	go hardware.LogTemperatures(messages)
 
+	// fmt.Println("Starting")
+	// out21 := devices.OutPin{Identifier: "GPIO21", FriendlyName: "GPIO21"}
+	// o := devices.OutputControl{HeatOutput: &out21, DutyCycle: 50, CycleTime: 4}
+	// go o.RunControl()
+
 	srv := handler.NewDefaultServer(generated.NewExecutableSchema(generated.Config{Resolvers: &graph.Resolver{}}))
 
 	if *graphiqlFlag {
@@ -65,4 +70,5 @@ func main() {
 			fmt.Printf("GraphiQL interface: http://%v%v/graphiql \n", name, fullPort)
 		}
 	}
+
 }


### PR DESCRIPTION
This adds a basic output control struct and methods, it performs the basic tasks of running the duty cycle and handling the output pin setup.

The tests use the gpiotest package from [periph.io](https://pkg.go.dev/periph.io/x/conn/v3@v3.6.7/gpio/gpiotest) which is super useful and is injected in.

I'm using monkey patching for time skipping because i'm lazy and this is just so much easier than adding a load of specific stuff for tests in classes