### PR TITLE
Add global shutdown hooks and wait groups

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/kr/pretty v0.2.1 // indirect
 	github.com/stretchr/testify v1.4.0
 	github.com/vektah/gqlparser/v2 v2.1.0
+	github.com/ztrue/shutdown v0.1.1
 	gorm.io/driver/sqlite v1.1.4
 	gorm.io/gorm v1.21.7
 	periph.io/x/periph v3.6.7+incompatible

--- a/go.sum
+++ b/go.sum
@@ -79,6 +79,8 @@ github.com/vektah/gqlparser/v2 v2.1.0 h1:uiKJ+T5HMGGQM2kRKQ8Pxw8+Zq9qhhZhz/lieYv
 github.com/vektah/gqlparser/v2 v2.1.0/go.mod h1:SyUiHgLATUR8BiYURfTirrTcGpcE+4XkV2se04Px1Ms=
 github.com/youchainhq/xgo2 v0.0.0-20200618040405-6eb1e55cdbcb h1:hD8hn6p2rjBGhlSwdutzW63DoFpV70muzrLVQIDKDik=
 github.com/youchainhq/xgo2 v0.0.0-20200618040405-6eb1e55cdbcb/go.mod h1:sLKRscBHxXotxxtBGnhy8khBIwrB7qmC8rHCvFUUZ8E=
+github.com/ztrue/shutdown v0.1.1 h1:GKR2ye2OSQlq1GNVE/s2NbrIMsFdmL+NdR6z6t1k+Tg=
+github.com/ztrue/shutdown v0.1.1/go.mod h1:hcMWcM2SwIsQk7Wb49aYme4tX66x6iLzs07w1OYAQLw=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=


### PR DESCRIPTION
(Kinda shitty but it works)

This uses a GoRoutine to start the webserver, and uses a WaitGroup to shut it down

```bash
pi@raspberrypi:~ $ ./elsinore/elsinore                                                                                                                         
Loading database                                                               
Loaded and looking for temperatures
Reading temps.                                                                 
2021/05/27 21:08:43 connect to http://localhost:8080/ for GraphQL playground
Server on 8080                                                                 
CORS API Listening on: http://raspberrypi:8080/graphql 
GraphiQL interface: http://raspberrypi:8080/graphiql 
```

Those last two lines never worked before, so now it's all gravy and I removed the additional lines ahead of it

I've using a `global` context for now because passing it around is a pain, but the shutdown hooks do all fire, so it's good, LEDs/GPIOs turn off on shutdown