### PR TITLE
Add support for switches in the backend

### DIFF
--- a/devices/outpin.go
+++ b/devices/outpin.go
@@ -31,7 +31,8 @@ func (op *OutPin) off() bool {
 
 	if op.PinIO == nil {
 		log.Warn().Msgf("Resetting off %v", op.Identifier)
-		op.reset()
+		err := op.reset()
+		if err != nil { return false }
 	}
 
 	if op.PinIO == nil {
@@ -59,7 +60,8 @@ func (op *OutPin) on() bool {
 
 	if op.PinIO == nil {
 		log.Warn().Msgf("Rsetting on %v", op.Identifier)
-		op.reset()
+		err := op.reset()
+		if err != nil { return false }
 	}
 
 	if op.PinIO == nil {
@@ -112,13 +114,18 @@ func (op *OutPin) reset() error {
 
 func (op *OutPin) update(identifier string) {
 	if len(strings.TrimSpace(identifier)) == 0 {
-		op.reset()
+		err := op.reset()
+		if err != nil { log.Warn().Err(err) }
 	} else if op.Identifier != identifier {
 		log.Warn().Msgf("Updating identifier %v", identifier)
-		op.reset()
+		err := op.reset()
+		if err != nil { log.Warn().Err(err) }
+
 		op.PinIO = nil
 		op.Identifier = identifier
-		op.reset()
+		
+		err = op.reset()
+		if err != nil { log.Warn().Err(err) }
 	}
 }
 

--- a/devices/outpin.go
+++ b/devices/outpin.go
@@ -1,0 +1,133 @@
+package devices
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/rs/zerolog/log"
+	"gorm.io/gorm"
+	"periph.io/x/periph/conn/gpio"
+	"periph.io/x/periph/conn/gpio/gpioreg"
+)
+
+var outpins []*OutPin = nil
+
+// OutPin represents a stored output pin with a friendly name
+type OutPin struct {
+	gorm.Model
+
+	Identifier   string
+	FriendlyName string
+	PinIO        gpio.PinIO `gorm:"-"`
+	onTime       *time.Time
+	offTime      *time.Time
+}
+
+func (op *OutPin) off() bool {
+	if op == nil {
+		return false
+	}
+
+	if op.PinIO == nil {
+		log.Warn().Msgf("Resetting off %v", op.Identifier)
+		op.reset()
+	}
+
+	if op.PinIO == nil {
+		log.Warn().Msgf("Cannot turn off %v", op.Identifier)
+		return false
+	}
+
+	if op.offTime != nil && op.PinIO.Read() == gpio.Low {
+		return false
+	}
+
+	if err := op.PinIO.Out(gpio.Low); err != nil {
+		log.Fatal().Err(err).Msgf("Failed to set %v to Low (off)", op.FriendlyName)
+	}
+	curTime := time.Now()
+	op.offTime = &curTime
+	op.onTime = nil
+	return true
+}
+
+func (op *OutPin) on() bool {
+	if op == nil {
+		return false
+	}
+
+	if op.PinIO == nil {
+		log.Warn().Msgf("Rsetting on %v", op.Identifier)
+		op.reset()
+	}
+
+	if op.PinIO == nil {
+		log.Warn().Msgf("Cannot turn on %v", op.Identifier)
+		return false
+	}
+
+	if op.onTime != nil && op.PinIO.Read() == gpio.High {
+		return false
+	}
+
+	if err := op.PinIO.Out(gpio.High); err != nil {
+		log.Fatal().Err(err).Msgf("Failed to set %v to High (on)", op.FriendlyName)
+	}
+
+	if op.PinIO.Read() != gpio.High {
+		log.Warn().Msg("Failed to turn pin on! resetting and trying again")
+		if err := op.PinIO.Out(gpio.High); err != nil {
+			log.Fatal().Err(err).Msgf("Failed to set %v to High (on)", op.FriendlyName)
+		}
+		if op.PinIO.Read() != gpio.High {
+			log.Warn().Msg("Failed to turn pin on!")
+		}
+	}
+	curTime := time.Now()
+	op.offTime = nil
+	op.onTime = &curTime
+	return true
+}
+
+func (op *OutPin) reset() error {
+	if len(strings.TrimSpace(op.Identifier)) == 0 {
+		if op != nil {
+			op.off()
+		}
+		return nil
+	}
+
+	if op.PinIO == nil {
+		op.PinIO = gpioreg.ByName(op.Identifier)
+		if op.PinIO == nil {
+			log.Error().Msgf("No Pin for %v!\n", op.Identifier)
+			return fmt.Errorf("no pin for %v", op.Identifier)
+		}
+	}
+	log.Warn().Msgf("Reset %v", op.Identifier)
+	op.off()
+	return nil
+}
+
+func (op *OutPin) update(identifier string) {
+	if len(strings.TrimSpace(identifier)) == 0 {
+		op.reset()
+	} else if op.Identifier != identifier {
+		log.Warn().Msgf("Updating identifier %v", identifier)
+		op.reset()
+		op.PinIO = nil
+		op.Identifier = identifier
+		op.reset()
+	}
+}
+
+// GpioInUse - Returns true if the GPIO specified is in use already
+func GpioInUse(identifier string) bool {
+	for _, outpin := range outpins {
+		if strings.EqualFold(outpin.Identifier, identifier) {
+			return true
+		}
+	}
+	return false
+}

--- a/devices/outpin.go
+++ b/devices/outpin.go
@@ -131,3 +131,26 @@ func GpioInUse(identifier string) bool {
 	}
 	return false
 }
+
+func deleteOutpin(outpin *OutPin) {
+	if outpin == nil {
+		return
+	}
+
+	for i, o := range outpins {
+		if o == outpin {
+			outpins[i] = outpins[len(outpins)-1]
+			outpins = outpins[:len(outpins)-1]
+			break
+		}
+	}
+}
+
+func createOutpin(identifier string, friendlyName string) (*OutPin, error) {
+	if GpioInUse(identifier) {
+		return nil, fmt.Errorf("GPIO '%v' is already in use", identifier)
+	}
+	newPin := &OutPin{Identifier: identifier, FriendlyName: friendlyName}
+	outpins = append(outpins, newPin)
+	return newPin, nil
+}

--- a/devices/output_control.go
+++ b/devices/output_control.go
@@ -40,10 +40,12 @@ func (o *OutputControl) Reset() {
 		return
 	}
 	if o.HeatOutput != nil {
-		o.HeatOutput.reset()
+		err := o.HeatOutput.reset()
+		if err != nil { log.Warn().Err(err) }
 	}
 	if o.CoolOutput != nil {
-		o.CoolOutput.reset()
+		err := o.CoolOutput.reset()
+		if err != nil { log.Warn().Err(err) }
 	}
 }
 
@@ -61,7 +63,8 @@ func (o *OutputControl) UpdateGpios(parentName string, heatGpio string, coolGpio
 	} else if o.HeatOutput != nil {
 		o.HeatOutput.update(heatGpio)
 		if emptyHeatGpio {
-			o.HeatOutput.reset()
+			err := o.HeatOutput.reset()
+			if err != nil { log.Warn().Err(err) }
 			o.HeatOutput = nil
 		}
 	}
@@ -75,7 +78,8 @@ func (o *OutputControl) UpdateGpios(parentName string, heatGpio string, coolGpio
 	} else if o.CoolOutput != nil {
 		o.CoolOutput.update(coolGpio)
 		if emptyCoolGpio {
-			o.CoolOutput.reset()
+			err := o.CoolOutput.reset()
+			if err != nil { log.Warn().Err(err) }
 			o.CoolOutput = nil
 		}
 	}

--- a/devices/switch.go
+++ b/devices/switch.go
@@ -1,0 +1,154 @@
+package devices
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/dougedey/elsinore/database"
+	"github.com/dougedey/elsinore/graph/model"
+	"github.com/rs/zerolog/log"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+	"periph.io/x/periph/conn/gpio"
+)
+
+var switches []*Switch = nil
+
+// AllSwitches returns all the switches, loading from the Database if none are configured
+func AllSwitches() []*Switch {
+	if switches == nil && database.FetchDatabase() != nil {
+		log.Info().Msg("Switches array is nil, checking the database...")
+		database.FetchDatabase().Debug().Preload(clause.Associations).Find(&switches)
+	}
+	return switches
+}
+
+// ShutdownAllSwitches - Turn off all switches that are configured, does not cover output control pins
+func ShutdownAllSwitches() {
+	if len(switches) == 0 {
+		log.Info().Msg("No switches to shutdown.\n")
+		return
+	}
+
+	log.Info().Msgf("Shutting down %v switches...\n", len(outpins))
+	for _, s := range switches {
+		log.Info().Msgf("Shutting down %v...", s.Output.FriendlyName)
+		s.Off()
+		log.Info().Msgf("Done %v!\n", s.Output.FriendlyName)
+	}
+}
+
+// FindSwitchByID - Find a temperature controller by id, preloading everything
+func FindSwitchByID(id string) *Switch {
+	intID, err := strconv.ParseUint(id, 10, 32)
+	if err != nil {
+		return nil
+	}
+
+	for i := range switches {
+		log.Info().Msgf("Comparing %v to %v\n", switches[i].ID, uint(intID))
+		if switches[i].ID == uint(intID) {
+			return switches[i]
+		}
+	}
+	var existingSwitch *Switch = nil
+	if database.FetchDatabase() == nil {
+		log.Printf("No Database configured, cannot lookup by Id")
+		return nil
+	}
+	result := database.FetchDatabase().Debug().Preload(clause.Associations).First(&existingSwitch, id)
+	if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+		return nil
+	}
+
+	return existingSwitch
+}
+
+// CreateSwitch - Create a new switch, checking for the GPIO/Name already existing
+func CreateSwitch(identifier string, friendlyName string) (*Switch, error) {
+	if GpioInUse(identifier) {
+		return nil, fmt.Errorf("GPIO '%v' is already in use", identifier)
+	}
+	for _, s := range switches {
+		if strings.EqualFold(s.Name(), friendlyName) {
+			return nil, fmt.Errorf("switch '%v' already exists", friendlyName)
+		}
+	}
+
+	newPin := OutPin{Identifier: identifier, FriendlyName: friendlyName}
+	newSwitch := Switch{Output: &newPin}
+	outpins = append(outpins, &newPin)
+	switches = append(switches, &newSwitch)
+	database.FetchDatabase().Debug().Save(&newSwitch)
+	return &newSwitch, nil
+}
+
+// Switch - Represents a thin wrapper around an OutPin to define a switch
+type Switch struct {
+	gorm.Model
+	OutputID uint
+	Output   *OutPin `gorm:"ForeignKey:OutputID"`
+	Inverted bool
+}
+
+// Reset - Turn off the switch if configured
+func (s *Switch) Reset() {
+	if s == nil || s.Output == nil {
+		return
+	}
+
+	s.Off()
+}
+
+// On - Switch on the output pin, if it's inverted, the pin goes to off
+func (s *Switch) On() {
+	if s.Output == nil {
+		return
+	}
+
+	if s.Inverted {
+		s.Output.off()
+	} else {
+		s.Output.on()
+	}
+}
+
+// Off - Switch off the output pin, if it's inverted, the pin goes to on
+func (s *Switch) Off() {
+	if s.Output == nil {
+		return
+	}
+
+	if s.Inverted {
+		s.Output.on()
+	} else {
+		s.Output.off()
+	}
+}
+
+// Gpio - Get the GPIO
+func (s *Switch) Gpio() string {
+	return s.Output.Identifier
+}
+
+// Name - Get the Name
+func (s *Switch) Name() string {
+	return s.Output.FriendlyName
+}
+
+// State - Returns on if this switch is on
+func (s *Switch) State() model.SwitchMode {
+	if s.Output.PinIO.Read() == s.onState() {
+		return model.SwitchModeOn
+	}
+	return model.SwitchModeOff
+}
+
+func (s *Switch) onState() gpio.Level {
+	if s.Inverted {
+		return gpio.Low
+	}
+	return gpio.High
+}

--- a/devices/temperature_controller.go
+++ b/devices/temperature_controller.go
@@ -291,7 +291,10 @@ func (c *TemperatureController) RunControl() {
 	}
 
 	ticker := time.NewTicker(duration)
-	c.configureOutputControl()
+	err = c.configureOutputControl()
+	if err != nil {
+		log.Fatal().Err(err).Msgf("Failed to configure output control for %v", c.Name)
+	}
 
 	c.Running = true
 

--- a/devices/temperature_controller_test.go
+++ b/devices/temperature_controller_test.go
@@ -18,7 +18,7 @@ func setupTestDb(t *testing.T) {
 	dbName := "test"
 	database.InitDatabase(&dbName,
 		&devices.TempProbeDetail{}, &devices.PidSettings{}, &devices.HysteriaSettings{},
-		&devices.ManualSettings{}, &devices.TemperatureController{},
+		&devices.ManualSettings{}, &devices.TemperatureController{}, &devices.Switch{},
 	)
 
 	t.Cleanup(func() {

--- a/graph/model/models_gen.go
+++ b/graph/model/models_gen.go
@@ -3,6 +3,9 @@
 package model
 
 import (
+	"fmt"
+	"io"
+	"strconv"
 	"time"
 )
 
@@ -52,6 +55,15 @@ type SettingsInput struct {
 	BreweryName *string `json:"breweryName"`
 }
 
+type SwitchSettingsInput struct {
+	// The Id of the switch, if no ID, create a new switch
+	ID *string `json:"id"`
+	// The new Name for the switch (required during switch creation)
+	Name *string `json:"name"`
+	// The new GPIO for the switch (required during switch creation)
+	Gpio *string `json:"gpio"`
+}
+
 // A device that reads a temperature and is assigned to a temperature controller
 type TempProbeDetails struct {
 	// The ID of an object
@@ -94,4 +106,45 @@ type TemperatureProbe struct {
 	Reading *string `json:"reading"`
 	// The time that this reading was updated
 	Updated *time.Time `json:"updated"`
+}
+
+type SwitchMode string
+
+const (
+	SwitchModeOn  SwitchMode = "on"
+	SwitchModeOff SwitchMode = "off"
+)
+
+var AllSwitchMode = []SwitchMode{
+	SwitchModeOn,
+	SwitchModeOff,
+}
+
+func (e SwitchMode) IsValid() bool {
+	switch e {
+	case SwitchModeOn, SwitchModeOff:
+		return true
+	}
+	return false
+}
+
+func (e SwitchMode) String() string {
+	return string(e)
+}
+
+func (e *SwitchMode) UnmarshalGQL(v interface{}) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("enums must be strings")
+	}
+
+	*e = SwitchMode(str)
+	if !e.IsValid() {
+		return fmt.Errorf("%s is not a valid SwitchMode", str)
+	}
+	return nil
+}
+
+func (e SwitchMode) MarshalGQL(w io.Writer) {
+	fmt.Fprint(w, strconv.Quote(e.String()))
 }

--- a/graph/resolver_test.go
+++ b/graph/resolver_test.go
@@ -802,4 +802,55 @@ func TestSwitches(t *testing.T) {
 		require.Equal(t, "GPIO2", toggleSwitchResp.ToggleSwitch.Gpio)
 		require.Equal(t, "off", toggleSwitchResp.ToggleSwitch.State)
 	})
+
+	var deleteSwitchResp struct {
+		DeleteSwitch struct {
+			Id    string
+			Name  string
+			Gpio  string
+			State string
+		}
+		Errors []struct {
+			Message   string
+			Locations []struct {
+				Line   int
+				Column int
+			}
+		}
+	}
+	t.Run("Can delete a switch", func(t *testing.T) {
+		c.MustPost(`
+			mutation {
+				deleteSwitch(id: 1) {
+					id
+					name
+					gpio
+					state
+				}
+			}
+		`, &deleteSwitchResp)
+
+		require.Empty(t, toggleSwitchResp.Errors, "no Errors should be returned")
+		require.Equal(t, "1", deleteSwitchResp.DeleteSwitch.Id)
+		require.Equal(t, "TestUpdate", deleteSwitchResp.DeleteSwitch.Name)
+		require.Equal(t, "GPIO2", deleteSwitchResp.DeleteSwitch.Gpio)
+		require.Equal(t, "off", deleteSwitchResp.DeleteSwitch.State)
+	})
+
+	t.Run("Can reuse a deleted switches GPIO", func(t *testing.T) {
+		c.MustPost(`
+			mutation {
+				modifySwitch(switchSettings: {name: "Test2", gpio: "GPIO1"} ) {
+					id
+					name
+					gpio
+				}
+			}
+		`, &switchResp)
+
+		require.Empty(t, switchResp.Errors, "no Errors should be returned")
+		require.Equal(t, "Test2", switchResp.ModifySwitch.Name)
+		require.Equal(t, "GPIO1", switchResp.ModifySwitch.Gpio)
+		require.Equal(t, "off", switchResp.ModifySwitch.State)
+	})
 }

--- a/graph/resolver_test.go
+++ b/graph/resolver_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/dougedey/elsinore/graph/model"
 	"github.com/dougedey/elsinore/hardware"
 	"github.com/stretchr/testify/require"
+	"periph.io/x/periph/conn/gpio/gpioreg"
+	"periph.io/x/periph/conn/gpio/gpiotest"
 	"periph.io/x/periph/conn/onewire"
 )
 
@@ -21,7 +23,7 @@ func setupTestDb(t *testing.T) {
 	dbName := "test"
 	database.InitDatabase(&dbName,
 		&devices.TempProbeDetail{}, &devices.PidSettings{}, &devices.HysteriaSettings{},
-		&devices.ManualSettings{}, &devices.TemperatureController{},
+		&devices.ManualSettings{}, &devices.TemperatureController{}, &devices.Switch{},
 	)
 	devices.ClearControllers()
 
@@ -610,5 +612,194 @@ func TestSystemSettings(t *testing.T) {
 			`Some Name`,
 			updateSettingsResp.UpdateSettings.BreweryName,
 		)
+	})
+}
+
+func TestSwitches(t *testing.T) {
+	setupTestDb(t)
+	c := client.New(handler.NewDefaultServer(generated.NewExecutableSchema(generated.Config{Resolvers: &graph.Resolver{}})))
+
+	var switchesListResp struct {
+		Switches []struct {
+			Id   string
+			Name string
+			Gpio string
+		}
+		Errors []struct {
+			Message   string
+			Locations []struct {
+				Line   int
+				Column int
+			}
+		}
+	}
+
+	var switchResp struct {
+		ModifySwitch struct {
+			Id    string
+			Name  string
+			Gpio  string
+			State string
+		}
+		Errors []struct {
+			Message   string
+			Locations []struct {
+				Line   int
+				Column int
+			}
+		}
+	}
+
+	t.Run(("Empty switch list is returned by default"), func(t *testing.T) {
+		c.MustPost(`
+			query {
+				switches {
+					id
+					name
+					gpio
+				}
+			}
+		`, &switchesListResp)
+
+		require.Empty(t, switchesListResp.Switches, "There should not be any switches configured")
+	})
+
+	gpioreg.Register(&gpiotest.Pin{N: "GPIO1", Num: 10, Fn: "I2C1_SDA"})
+	gpioreg.Register(&gpiotest.Pin{N: "GPIO2", Num: 11, Fn: "I2C1_SDC"})
+
+	t.Run("Can create a new switch", func(t *testing.T) {
+		c.MustPost(`
+			mutation {
+				modifySwitch(switchSettings: {name: "Test", gpio: "GPIO1"} ) {
+					id
+					name
+					gpio
+					state
+				}
+			}
+		`, &switchResp)
+
+		require.Empty(t, switchResp.Errors, "no Errors should be returned")
+		require.Equal(t, "Test", switchResp.ModifySwitch.Name)
+		require.Equal(t, "GPIO1", switchResp.ModifySwitch.Gpio)
+		require.Equal(t, "off", switchResp.ModifySwitch.State)
+	})
+
+	t.Run("Cannot create a new switch with a GPIO in use already", func(t *testing.T) {
+		err := c.Post(`
+			mutation {
+				modifySwitch(switchSettings: {name: "Test2", gpio: "GPIO1"} ) {
+					id
+					name
+					gpio
+				}
+			}
+		`, &switchResp)
+
+		require.NotNil(t, err)
+		require.Equal(t,
+			`[{"message":"GPIO 'GPIO1' is already in use","path":["modifySwitch"]}]`,
+			err.Error(),
+		)
+	})
+
+	t.Run("Cannot create a new switch with an existing name", func(t *testing.T) {
+		err := c.Post(`
+			mutation {
+				modifySwitch(switchSettings: {name: "Test", gpio: "GPIO2"} ) {
+					id
+					name
+					gpio
+				}
+			}
+		`, &switchResp)
+
+		require.NotNil(t, err)
+		require.Equal(t,
+			`[{"message":"switch 'Test' already exists","path":["modifySwitch"]}]`,
+			err.Error(),
+		)
+	})
+
+	t.Run(("The switch list is returned when switches are configured"), func(t *testing.T) {
+		c.MustPost(`
+			query {
+				switches {
+					id
+					name
+					gpio
+				}
+			}
+		`, &switchesListResp)
+
+		require.Len(t, switchesListResp.Switches, 1, "One switch should exist")
+	})
+
+	t.Run("Can update an existing switch", func(t *testing.T) {
+		c.MustPost(`
+			mutation {
+				modifySwitch(switchSettings: {id: 1, name: "TestUpdate", gpio: "GPIO2"} ) {
+					id
+					name
+					gpio
+				}
+			}
+		`, &switchResp)
+
+		require.Empty(t, switchResp.Errors, "no Errors should be returned")
+		require.Equal(t, "TestUpdate", switchResp.ModifySwitch.Name)
+		require.Equal(t, "GPIO2", switchResp.ModifySwitch.Gpio)
+	})
+
+	var toggleSwitchResp struct {
+		ToggleSwitch struct {
+			Id    string
+			Name  string
+			Gpio  string
+			State string
+		}
+		Errors []struct {
+			Message   string
+			Locations []struct {
+				Line   int
+				Column int
+			}
+		}
+	}
+
+	t.Run("Can turn a switch on", func(t *testing.T) {
+		c.MustPost(`
+			mutation {
+				toggleSwitch(id: 1, mode: on ) {
+					id
+					name
+					gpio
+					state
+				}
+			}
+		`, &toggleSwitchResp)
+
+		require.Empty(t, toggleSwitchResp.Errors, "no Errors should be returned")
+		require.Equal(t, "TestUpdate", toggleSwitchResp.ToggleSwitch.Name)
+		require.Equal(t, "GPIO2", toggleSwitchResp.ToggleSwitch.Gpio)
+		require.Equal(t, "on", toggleSwitchResp.ToggleSwitch.State)
+	})
+
+	t.Run("Can turn a switch off", func(t *testing.T) {
+		c.MustPost(`
+			mutation {
+				toggleSwitch(id: 1, mode: off ) {
+					id
+					name
+					gpio
+					state
+				}
+			}
+		`, &toggleSwitchResp)
+
+		require.Empty(t, toggleSwitchResp.Errors, "no Errors should be returned")
+		require.Equal(t, "TestUpdate", toggleSwitchResp.ToggleSwitch.Name)
+		require.Equal(t, "GPIO2", toggleSwitchResp.ToggleSwitch.Gpio)
+		require.Equal(t, "off", toggleSwitchResp.ToggleSwitch.State)
 	})
 }

--- a/graph/schema.graphqls
+++ b/graph/schema.graphqls
@@ -13,6 +13,11 @@ enum ControllerMode {
   hysteria
 }
 
+enum SwitchMode {
+  on
+  off
+}
+
 scalar Time
 
 """The settings for hysteria mode"""
@@ -56,6 +61,16 @@ type Mutation {
   
   """Update the current system settings"""
   updateSettings(settings: SettingsInput!): Settings
+
+  """
+  Create or update a switch
+  """
+  modifySwitch(switchSettings: SwitchSettingsInput!): Switch
+  """
+  Enable or disable a switch
+  """
+  toggleSwitch(id: ID!, mode: SwitchMode!): Switch
+
 }
 
 """The settings for heating or cooling on a temperature controller"""
@@ -126,6 +141,9 @@ type Query {
 
   """Fetch the current System Settings"""
   settings: Settings
+
+  """Fetch switches that are configured"""
+  switches: [Switch]
 }
 
 type TemperatureController {
@@ -268,4 +286,30 @@ type Settings {
 input SettingsInput {
   """The new brewery name (blank for no change)"""
   breweryName: String
+}
+
+type Switch {
+  """The ID of the switch"""
+  id: ID!
+  """The GPIO for the pin"""
+  gpio: String!
+  """The name of the switch"""
+  name: String!
+  """The state of the switch"""
+  state: SwitchMode!
+}
+
+input SwitchSettingsInput {
+  """
+  The Id of the switch, if no ID, create a new switch
+  """
+  id: ID
+  """
+  The new Name for the switch (required during switch creation)
+  """
+  name: String
+  """
+  The new GPIO for the switch (required during switch creation)
+  """
+  gpio: String
 }

--- a/graph/schema.graphqls
+++ b/graph/schema.graphqls
@@ -67,10 +67,13 @@ type Mutation {
   """
   modifySwitch(switchSettings: SwitchSettingsInput!): Switch
   """
+  Delete a switch
+  """
+  deleteSwitch(id: ID!): Switch
+  """
   Enable or disable a switch
   """
   toggleSwitch(id: ID!, mode: SwitchMode!): Switch
-
 }
 
 """The settings for heating or cooling on a temperature controller"""

--- a/graph/schema.resolvers.go
+++ b/graph/schema.resolvers.go
@@ -104,6 +104,10 @@ func (r *mutationResolver) ModifySwitch(ctx context.Context, switchSettings mode
 	return curSwitch, nil
 }
 
+func (r *mutationResolver) DeleteSwitch(ctx context.Context, id string) (*devices.Switch, error) {
+	return devices.DeleteSwitchByID(id)
+}
+
 func (r *mutationResolver) ToggleSwitch(ctx context.Context, id string, mode model.SwitchMode) (*devices.Switch, error) {
 	s := devices.FindSwitchByID(id)
 	if strings.EqualFold("on", mode.String()) {

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strings"
 	"sync"
 	"time"
 
@@ -52,9 +53,10 @@ func main() {
 	database.InitDatabase(dbName,
 		&devices.TempProbeDetail{}, &devices.PidSettings{}, &devices.HysteriaSettings{},
 		&devices.ManualSettings{}, &devices.TemperatureController{}, &system.Settings{},
+		&devices.Switch{},
 	)
 
-	if system.CurrentSettings().BreweryName == "" {
+	if len(strings.TrimSpace(system.CurrentSettings().BreweryName)) == 0 {
 		system.CurrentSettings().BreweryName = "Elsinore"
 		system.CurrentSettings().Save()
 	}
@@ -76,6 +78,8 @@ func main() {
 		controller.Mode = "off"
 	}
 	go temperatureControllerRunner()
+
+	log.Printf("Loaded %v switches.", len(devices.AllSwitches()))
 
 	httpServerExitDone := &sync.WaitGroup{}
 


### PR DESCRIPTION
Super simple, but well tested right now, this adds support for switches as a wrapper around OutPins, with validations for duplicate names/GPIOs

This also has support for deletion, and adds some after commit stuff to ensure that when we delete Output controls and Switches, we remove the in memory stuff