### PR TITLE
Switch SetPoint to be a pointer so it can be set to nothing

### DIFF
--- a/devices/outpin.go
+++ b/devices/outpin.go
@@ -32,7 +32,9 @@ func (op *OutPin) off() bool {
 	if op.PinIO == nil {
 		log.Warn().Msgf("Resetting off %v", op.Identifier)
 		err := op.reset()
-		if err != nil { return false }
+		if err != nil {
+			return false
+		}
 	}
 
 	if op.PinIO == nil {
@@ -61,7 +63,9 @@ func (op *OutPin) on() bool {
 	if op.PinIO == nil {
 		log.Warn().Msgf("Rsetting on %v", op.Identifier)
 		err := op.reset()
-		if err != nil { return false }
+		if err != nil {
+			return false
+		}
 	}
 
 	if op.PinIO == nil {
@@ -115,17 +119,23 @@ func (op *OutPin) reset() error {
 func (op *OutPin) update(identifier string) {
 	if len(strings.TrimSpace(identifier)) == 0 {
 		err := op.reset()
-		if err != nil { log.Warn().Err(err) }
+		if err != nil {
+			log.Warn().Err(err)
+		}
 	} else if op.Identifier != identifier {
 		log.Warn().Msgf("Updating identifier %v", identifier)
 		err := op.reset()
-		if err != nil { log.Warn().Err(err) }
+		if err != nil {
+			log.Warn().Err(err)
+		}
 
 		op.PinIO = nil
 		op.Identifier = identifier
-		
+
 		err = op.reset()
-		if err != nil { log.Warn().Err(err) }
+		if err != nil {
+			log.Warn().Err(err)
+		}
 	}
 }
 

--- a/devices/output_control.go
+++ b/devices/output_control.go
@@ -41,11 +41,15 @@ func (o *OutputControl) Reset() {
 	}
 	if o.HeatOutput != nil {
 		err := o.HeatOutput.reset()
-		if err != nil { log.Warn().Err(err) }
+		if err != nil {
+			log.Warn().Err(err)
+		}
 	}
 	if o.CoolOutput != nil {
 		err := o.CoolOutput.reset()
-		if err != nil { log.Warn().Err(err) }
+		if err != nil {
+			log.Warn().Err(err)
+		}
 	}
 }
 
@@ -64,7 +68,9 @@ func (o *OutputControl) UpdateGpios(parentName string, heatGpio string, coolGpio
 		o.HeatOutput.update(heatGpio)
 		if emptyHeatGpio {
 			err := o.HeatOutput.reset()
-			if err != nil { log.Warn().Err(err) }
+			if err != nil {
+				log.Warn().Err(err)
+			}
 			o.HeatOutput = nil
 		}
 	}
@@ -79,7 +85,9 @@ func (o *OutputControl) UpdateGpios(parentName string, heatGpio string, coolGpio
 		o.CoolOutput.update(coolGpio)
 		if emptyCoolGpio {
 			err := o.CoolOutput.reset()
-			if err != nil { log.Warn().Err(err) }
+			if err != nil {
+				log.Warn().Err(err)
+			}
 			o.CoolOutput = nil
 		}
 	}

--- a/devices/temperature_controller_test.go
+++ b/devices/temperature_controller_test.go
@@ -297,7 +297,7 @@ func TestTemperatureControllerUpdateOutput(t *testing.T) {
 		outputControl := devices.OutputControl{HeatOutput: &out21}
 		temperatureController.OutputControl = &outputControl
 		temperatureController.HeatSettings = devices.PidSettings{Configured: true, CycleTime: 12, Proportional: 1}
-		temperatureController.SetPointRaw.Set("40C")
+		temperatureController.UpdateSetPoint("40C")
 		temperatureController.UpdateOutput()
 
 		if outputControl.CycleTime != temperatureController.HeatSettings.CycleTime {
@@ -313,7 +313,7 @@ func TestTemperatureControllerUpdateOutput(t *testing.T) {
 		temperatureController.OutputControl = &outputControl
 		temperatureController.HeatSettings.Configured = false
 		temperatureController.CoolSettings = devices.PidSettings{Configured: true, CycleTime: 13, Proportional: 1}
-		temperatureController.SetPointRaw.Set("40C")
+		temperatureController.UpdateSetPoint("40C")
 		temperatureController.UpdateOutput()
 
 		if outputControl.CycleTime != temperatureController.CoolSettings.CycleTime {
@@ -388,6 +388,8 @@ func TestTemperatureControllerCalculate(t *testing.T) {
 		}
 	})
 
+	temperatureController.UpdateSetPoint("36C")
+
 	t.Run("Calculate updates previous time when the difference is over 100ms", func(t *testing.T) {
 		offset := int64(rand.Intn(100)+100) * 1_000_000
 		stubNext := func() time.Time { return time.Unix(1615715366, offset) }
@@ -403,7 +405,7 @@ func TestTemperatureControllerCalculate(t *testing.T) {
 	t.Run("Calculate uses proportional value when set", func(t *testing.T) {
 		temperatureController.HeatSettings.Proportional = 10
 		temperatureController.PreviousCalculationTime = stubNow()
-		temperatureController.SetPointRaw.Set("36C")
+
 		offset := int64(rand.Intn(100)+100) * 1_000_000
 		stubNext := func() time.Time { return time.Unix(1615715366, offset) }
 		var output = temperatureController.Calculate(temperatureController.AverageTemperature(), stubNext)
@@ -418,7 +420,7 @@ func TestTemperatureControllerCalculate(t *testing.T) {
 	t.Run("Calculate uses proportional value when set with a large delta caps to 100", func(t *testing.T) {
 		temperatureController.HeatSettings.Proportional = 10
 		temperatureController.PreviousCalculationTime = stubNow()
-		temperatureController.SetPointRaw.Set("100C")
+		temperatureController.UpdateSetPoint("100C")
 		offset := int64(rand.Intn(100)+100) * 1_000_000
 		stubNext := func() time.Time { return time.Unix(1615715366, offset) }
 		var output = temperatureController.Calculate(temperatureController.AverageTemperature(), stubNext)
@@ -434,7 +436,7 @@ func TestTemperatureControllerCalculate(t *testing.T) {
 		temperatureController.HeatSettings.Proportional = 10
 		temperatureController.HeatSettings.Integral = 0
 		temperatureController.PreviousCalculationTime = stubNow()
-		temperatureController.SetPointRaw.Set("36C")
+		temperatureController.UpdateSetPoint("36C")
 		offset := int64((101 + 100) * 1_000_000)
 		stubNext := func() time.Time { return time.Unix(1615715366, offset) }
 		var output = temperatureController.Calculate(temperatureController.AverageTemperature(), stubNext)


### PR DESCRIPTION
Right now, the default set point is the default physic.Temperature value of zero degrees kelvin, or -273.150 celsius, this fixes that by allowing the SetPoint to be set to nothing, effectively disabling the output control. I'll probably need to add validations to this, but for now, it's good.

Also this means that the `no setpoint` temperature is `""` as a response, and it handles lowercase inputs `24c` -> `24C` just to make life easier.