### PR TITLE
Minor tweaks

### DIFF
--- a/devices/output_control.go
+++ b/devices/output_control.go
@@ -97,7 +97,7 @@ func (o *OutputControl) UpdateGpios(parentName string, heatGpio string, coolGpio
 // CalculateOutput - Turn on and off the output pin for this output control depending on the duty cycle
 func (o *OutputControl) CalculateOutput() {
 	cycleSeconds := math.Abs(float64(o.CycleTime*o.DutyCycle) / 100)
-	if o.DutyCycle == 0 {
+	if cycleSeconds == 0 {
 		o.HeatOutput.off()
 		o.CoolOutput.off()
 	} else if o.DutyCycle == 100 {

--- a/devices/temperature_controller.go
+++ b/devices/temperature_controller.go
@@ -382,11 +382,15 @@ func (c *TemperatureController) UpdateSetPoint(newValue string) error {
 		return nil
 	}
 
+	clearOnError := false
 	if c.SetPointRaw == nil {
 		newTemp := physic.Temperature(0)
 		c.SetPointRaw = &newTemp
+		clearOnError = true
 	}
-	return c.SetPointRaw.Set(strings.ToUpper(newValue))
+	err := c.SetPointRaw.Set(strings.ToUpper(newValue))
+	if clearOnError && err != nil { c.SetPointRaw = nil }
+	return err
 }
 
 // MaxTemp -> For hysteria, this is the string for the max temp to turn off


### PR DESCRIPTION
When creating a new set point, delete it if we cannot create it because of a typo

Use the cycle seconds to detemrine output status